### PR TITLE
fix re_camel_case for Win32 word

### DIFF
--- a/vkdgen.py
+++ b/vkdgen.py
@@ -16,7 +16,7 @@ re_funcptr = re.compile(r"^typedef (.+) \(VKAPI_PTR \*$")
 re_single_const = re.compile(r"^const\s+(.+)\*\s*$")
 re_double_const = re.compile(r"^const\s+(.+)\*\s+const\*\s*$")
 re_array = re.compile(r"^([^\[]+)\[(\d+)\]$")
-re_camel_case = re.compile(r"([a-z])([A-Z])")
+re_camel_case = re.compile(r"([a-z0-9])([A-Z])")
 re_long_int = re.compile(r"([0-9]+)ULL")
 
 if __name__ == "__main__":


### PR DESCRIPTION
example

VkStructureType sType = VkStructureType.VK_STRUCTURE_TYPE_WIN32SURFACE_CREATE_INFO_KHR;

to

VkStructureType sType = VkStructureType.VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR;
