### PR TITLE
add removeExtensions

### DIFF
--- a/vkdgen.py
+++ b/vkdgen.py
@@ -494,5 +494,6 @@ if __name__ == "__main__":
 		emitversions=".*",
 		#defaultExtensions="defaultExtensions",
 		addExtensions=r".*",
-		removeExtensions = r"VK_KHR_.*_surface$",
+		# In order to prevent the platform-specific type is introduced 
+		removeExtensions = r"VK_(KHR_.*_surface|AMD_.*|NV_.*|NVX_.*|GOOGLE_.*|.*_extension_\d+)$",
 	))


### PR DESCRIPTION
- in order to prevent the platform-specific type is introduced

version(DVulkan_VK_NV_external_memory_win32)
alias PFN_vkGetMemoryWin32HandleNV = VkResult function(VkDevice device,VkDeviceMemory memory,VkExternalMemoryHandleTypeFlagsNV handleType,HANDLE\* pHandle);
- number suffixed extensions has no function and types, but only extension enum.

version(DVulkan_VK_KHR_extension_60) {
    enum VK_KHR_EXTENSION_60_SPEC_VERSION = 0;
    enum VK_KHR_EXTENSION_60_EXTENSION_NAME = "VK_KHR_extension_60";
}
